### PR TITLE
Get exceptions now bubble when not cased

### DIFF
--- a/src/Http/Adapters/GuzzleHttpAdapter.php
+++ b/src/Http/Adapters/GuzzleHttpAdapter.php
@@ -171,6 +171,9 @@ class GuzzleHttpAdapter implements HttpInterface {
         {
             case 404:
                 throw new NotFoundException();
+                break;
+            default:
+                throw $exception;
         }
     }
 


### PR DESCRIPTION
Get queries exceptions are caught but only the 404 case was handled which meant that anything else could not be handled by code calling the adapter. Anything unhandled is now passed on.
